### PR TITLE
fix: Warning message displayed twice in chat history update

### DIFF
--- a/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
+++ b/code/frontend/src/pages/chat/ChatHistoryListItem.tsx
@@ -215,7 +215,7 @@ export const ChatHistoryListItemCell: React.FC<
                     placeholder={item.title}
                     onChange={chatHistoryTitleOnChange}
                     onKeyDown={handleKeyPressEdit}
-                    errorMessage={errorRename}
+                    // errorMessage={errorRename}
                     disabled={errorRename ? true : false}
                   />
                 </Stack.Item>


### PR DESCRIPTION
## Purpose
* Fixed issue with duplicate warning messages in chat history update

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check

1. Deploy CWYD with GPT 4o
2. Go to CWYD Admin and enable chat history if not enabled
3. Go to CWYD web url and save chat history conversations
4. Click on Show chat history button and click on Edit icon for a chat thread
5. Disconnect from network
6. Update the text in chat thread title and click on Tick icon
7. Observe the warning message
8. **The warning message "Error: could not rename file" should be displayed only once.**
