### PR TITLE
chore: Redirect Dependabot PRs to 'dependentbotchanges' for Pre-Merge Testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
     commit-message:
       prefix: "build"
+    target-branch: "dependabotchanges"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+
+
     commit-message:
       prefix: "build"
     groups:
@@ -21,17 +25,24 @@ updates:
         patterns:
           - "langchain*"
     open-pull-requests-limit: 50
+    target-branch: "dependabotchanges"
   - package-ecosystem: "npm"
     directory: "/code/frontend"
     schedule:
       interval: "weekly"
+
+
     commit-message:
       prefix: "build"
     open-pull-requests-limit: 50
+    target-branch: "dependabotchanges"
   - package-ecosystem: "npm"
     directory: "/tests/integration/ui"
     schedule:
       interval: "weekly"
+
+
     commit-message:
       prefix: "build"
     open-pull-requests-limit: 50
+    target-branch: "dependabotchanges"

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,44 @@
+name: Sync Main to dependabotchanges
+
+on:
+  # Schedule the sync job to run daily or customize as needed
+  schedule:
+    - cron: '0 1 * * *'  # Runs every day at 1 AM UTC
+  # Trigger the sync job on pushes to the main branch
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch all history for accurate branch comparison
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync main to dependabotchanges
+        run: |
+          # Ensure we're on the main branch
+          git checkout main
+          # Fetch the latest changes
+          git pull origin main
+
+          # Switch to dependabotchanges branch
+          git checkout dependabotchanges
+          # Merge main branch changes
+          git merge main --no-edit
+
+          # Push changes back to dependabotchanges branch
+          git push origin dependabotchanges
+
+      - name: Notify on Failure
+        if: failure()
+        run: echo "Sync from main to dependabotchanges failed!"


### PR DESCRIPTION
## Purpose
This PR modifies the Dependabot configuration to direct update PRs to a new branch, `dependentbotchanges`, rather than the main branch. This approach ensures that package updates are thoroughly tested before merging, reducing the risk of untested changes breaking deployments.

Currently, Dependabot opens PRs directly in the main branch, which may introduce issues if package updates are not validated in advance. By using the `dependentbotchanges` branch, we can safely test updates and perform deployment testing and golden path verification to confirm stability before merging.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No



## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
1. Verify that Dependabot updates are directed to the `dependentbotchanges` branch.

```
```

## What to Check
Verify that:
* Dependabot PRs are created in `dependentbotchanges` instead of `main`.

* ...

