### PR TITLE
chore: update Dependabot interval from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
     commit-message:
       prefix: "build"
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
 
     commit-message:
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/code/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
 
     commit-message:
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/tests/integration/ui"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
 
     commit-message:


### PR DESCRIPTION
## Purpose
Update the interval for Dependabot from weekly to monthly to reduce the frequency of dependency update PRs.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```


## What to Check
The interval in .github/dependabot.yml is set to monthly.


